### PR TITLE
Update to Support Symfony 5.x.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,8 +27,8 @@
     "require": {
         "php": ">=5.4",
         "symfony/console": "^2.8|^3.0|^4.0",
-        "symfony/config": "^2.8|^3.0|^4.0",
-        "symfony/yaml": "^2.8|^3.0|^4.0"
+        "symfony/config": "^2.8|^3.0|^4.0|^5.0",
+        "symfony/yaml": "^2.8|^3.0|^4.0|^5.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8.35|^5.7|^6.5",

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     }],
     "require": {
         "php": ">=5.4",
-        "symfony/console": "^2.8|^3.0|^4.0",
+        "symfony/console": "^2.8|^3.0|^4.0|^5.0",
         "symfony/config": "^2.8|^3.0|^4.0|^5.0",
         "symfony/yaml": "^2.8|^3.0|^4.0|^5.0"
     },

--- a/src/Phinx/Console/Command/Breakpoint.php
+++ b/src/Phinx/Console/Command/Breakpoint.php
@@ -29,6 +29,7 @@
  */
 namespace Phinx\Console\Command;
 
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -66,7 +67,7 @@ EOT
      *
      * @param \Symfony\Component\Console\Input\InputInterface $input
      * @param \Symfony\Component\Console\Output\OutputInterface $output
-     * @return void
+     * @return int
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
@@ -94,5 +95,7 @@ EOT
             // Toggle the breakpoint.
             $this->getManager()->toggleBreakpoint($environment, $version);
         }
+
+        return Command::SUCCESS;
     }
 }

--- a/src/Phinx/Console/Command/Create.php
+++ b/src/Phinx/Console/Command/Create.php
@@ -30,6 +30,7 @@ namespace Phinx\Console\Command;
 
 use Phinx\Config\NamespaceAwareInterface;
 use Phinx\Util\Util;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -146,7 +147,7 @@ class Create extends AbstractCommand
      * @param \Symfony\Component\Console\Output\OutputInterface $output
      * @throws \RuntimeException
      * @throws \InvalidArgumentException
-     * @return void
+     * @return int
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
@@ -310,5 +311,7 @@ class Create extends AbstractCommand
         }
 
         $output->writeln('<info>created</info> ' . str_replace(getcwd() . DIRECTORY_SEPARATOR, '', $filePath));
+
+        return Command::SUCCESS;
     }
 }

--- a/src/Phinx/Console/Command/Init.php
+++ b/src/Phinx/Console/Command/Init.php
@@ -57,7 +57,7 @@ class Init extends Command
      * @param \Symfony\Component\Console\Output\OutputInterface $output
      * @throws \RuntimeException
      * @throws \InvalidArgumentException
-     * @return void
+     * @return int
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
@@ -103,5 +103,7 @@ class Init extends Command
         }
 
         $output->writeln('<info>created</info> .' . str_replace(getcwd(), '', $filePath));
+
+        return Command::SUCCESS;
     }
 }

--- a/src/Phinx/Console/Command/Rollback.php
+++ b/src/Phinx/Console/Command/Rollback.php
@@ -28,6 +28,7 @@
  */
 namespace Phinx\Console\Command;
 
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -75,7 +76,7 @@ EOT
      *
      * @param \Symfony\Component\Console\Input\InputInterface $input
      * @param \Symfony\Component\Console\Output\OutputInterface $output
-     * @return void
+     * @return int
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
@@ -126,6 +127,8 @@ EOT
 
         $output->writeln('');
         $output->writeln('<comment>All Done. Took ' . sprintf('%.4fs', $end - $start) . '</comment>');
+
+        return Command::SUCCESS;
     }
 
     /**

--- a/src/Phinx/Console/Command/SeedCreate.php
+++ b/src/Phinx/Console/Command/SeedCreate.php
@@ -30,6 +30,7 @@ namespace Phinx\Console\Command;
 
 use Phinx\Config\NamespaceAwareInterface;
 use Phinx\Util\Util;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -132,7 +133,7 @@ class SeedCreate extends AbstractCommand
      * @param \Symfony\Component\Console\Output\OutputInterface $output
      * @throws \RuntimeException
      * @throws \InvalidArgumentException
-     * @return void
+     * @return int
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
@@ -195,5 +196,7 @@ class SeedCreate extends AbstractCommand
 
         $output->writeln('<info>using seed base class</info> ' . $classes['$useClassName']);
         $output->writeln('<info>created</info> .' . str_replace(getcwd(), '', $filePath));
+
+        return Command::SUCCESS;
     }
 }

--- a/src/Phinx/Console/Command/SeedRun.php
+++ b/src/Phinx/Console/Command/SeedRun.php
@@ -28,6 +28,7 @@
  */
 namespace Phinx\Console\Command;
 
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -64,7 +65,7 @@ EOT
      *
      * @param \Symfony\Component\Console\Input\InputInterface $input
      * @param \Symfony\Component\Console\Output\OutputInterface $output
-     * @return void
+     * @return int
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
@@ -94,7 +95,7 @@ EOT
         } else {
             $output->writeln('<error>Could not determine database name! Please specify a database name in your config file.</error>');
 
-            return;
+            return Command::FAILURE;
         }
 
         if (isset($envOptions['table_prefix'])) {
@@ -120,5 +121,7 @@ EOT
 
         $output->writeln('');
         $output->writeln('<comment>All Done. Took ' . sprintf('%.4fs', $end - $start) . '</comment>');
+
+        return Command::SUCCESS;
     }
 }

--- a/src/Phinx/Console/Command/Test.php
+++ b/src/Phinx/Console/Command/Test.php
@@ -30,6 +30,7 @@ namespace Phinx\Console\Command;
 
 use Phinx\Migration\Manager\Environment;
 use Phinx\Util\Util;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -68,7 +69,7 @@ EOT
      * @param \Symfony\Component\Console\Output\OutputInterface $output
      * @throws \RuntimeException
      * @throws \InvalidArgumentException
-     * @return void
+     * @return int
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
@@ -106,5 +107,7 @@ EOT
         }
 
         $output->writeln('<info>success!</info>');
+
+        return Command::SUCCESS;
     }
 }

--- a/tests/Phinx/Console/Command/CreateTest.php
+++ b/tests/Phinx/Console/Command/CreateTest.php
@@ -384,7 +384,7 @@ class CreateTest extends TestCase
     {
         if (method_exists($this, 'expectException')) {
             //PHPUnit 5+
-            $this->expectException($exception);
+            $this->expectException($exceptionName);
             if ($exceptionMessage !== '') {
                 $this->expectExceptionMessage($exceptionMessage);
             }

--- a/tests/Phinx/Migration/ManagerTest.php
+++ b/tests/Phinx/Migration/ManagerTest.php
@@ -5710,7 +5710,7 @@ class ManagerTest extends TestCase
     {
         if (method_exists($this, 'expectException')) {
             //PHPUnit 5+
-            $this->expectException($exception);
+            $this->expectException($exceptionName);
             if ($exceptionMessage !== '') {
                 $this->expectExceptionMessage($exceptionMessage);
             }


### PR DESCRIPTION
This introduces the updates required for this package to support Symfony 5 components. The updates were tested using the testsuite included in the library using PHP 7.2.